### PR TITLE
fix: time picker input shift when navigating between time fields

### DIFF
--- a/content/snippets/time-picker-input.mdx
+++ b/content/snippets/time-picker-input.mdx
@@ -99,7 +99,7 @@ const TimePickerInput = React.forwardRef<
         id={id || picker}
         name={name || picker}
         className={cn(
-          "w-[46px] font-mono text-base tabular-nums caret-transparent focus:bg-accent focus:text-accent-foreground [&::-webkit-inner-spin-button]:appearance-none",
+          "w-[48px] text-center font-mono text-base tabular-nums caret-transparent focus:bg-accent focus:text-accent-foreground [&::-webkit-inner-spin-button]:appearance-none",
           className
         )}
         value={value || calculatedValue}

--- a/src/components/time-picker/time-picker-input.tsx
+++ b/src/components/time-picker/time-picker-input.tsx
@@ -90,7 +90,7 @@ const TimePickerInput = React.forwardRef<
         id={id || picker}
         name={name || picker}
         className={cn(
-          "w-[46px] font-mono text-base tabular-nums caret-transparent focus:bg-accent focus:text-accent-foreground [&::-webkit-inner-spin-button]:appearance-none",
+          "w-[48px] text-center font-mono text-base tabular-nums caret-transparent focus:bg-accent focus:text-accent-foreground [&::-webkit-inner-spin-button]:appearance-none",
           className
         )}
         value={value || calculatedValue}


### PR DESCRIPTION
## Description

Super minor but this fixes the visual shift of the input field content when navigating between the individual time fields. Doesn't seem to occur on chrome (v119) or firefox (v119) but does on Safari 17 (not sure if others are experiencing it). Increased the width of the input by 2px and center aligned the text. Thanks for the great component!

Video: 

https://github.com/openstatusHQ/time-picker/assets/12883356/01716332-1554-4a90-a33c-cf79acb12881

