### PR TITLE
feature: add a component to support 12-hour clocks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
 import { ModeToggle } from "@/components/theme/toggle-mode";
 import { Github, Globe, Twitter } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { TimePicker12HourWrapper } from "@/components/time-picker/time-picker-12hour-wrapper";
 
 const snippets = allSnippets.sort((a, b) => a.order - b.order);
 
@@ -53,11 +54,11 @@ export default function Home() {
         </div>
         <div className="flex-1 min-h-full flex flex-col">
           <div className="grid grid-cols-1 md:grid-cols-2 pb-4">
-            {/* <DatePickerDemo /> */}
             <div className="grid pb-4 md:pb-0 md:pr-4">
               <div className="flex flex-col gap-3 pb-4 border-b border-border">
                 <h3 className="text-xl font-cal">Demo</h3>
                 <TimePickerWrapper />
+                <TimePicker12HourWrapper />
               </div>
               <div className="pt-4 flex flex-col gap-3">
                 <ul className="list-disc list-outside ml-5 marker:text-muted-foreground space-y-2 text-sm">
@@ -91,7 +92,15 @@ export default function Home() {
                   >
                     Input
                   </a>{" "}
-                  component
+                  component (twelve-hour clocks also need the{" "}
+                  <a
+                    href="https://ui.shadcn.com/docs/components/select"
+                    className="font-mono underline hover:no-underline"
+                    target="_blank"
+                  >
+                    Select
+                  </a>{" "}
+                  component)
                 </li>
                 <li>
                   Copy & paste{" "}

--- a/src/components/time-picker/date-time-picker-demo.tsx
+++ b/src/components/time-picker/date-time-picker-demo.tsx
@@ -13,6 +13,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { TimePickerDemo } from "./time-picker-demo";
+import { TimePicker12Demo } from "./time-picker-12hour-demo";
 
 export function DatePickerDemo() {
   const [date, setDate] = React.useState<Date>();
@@ -39,7 +40,8 @@ export function DatePickerDemo() {
           initialFocus
         />
         <div className="p-3 border-t border-border">
-          <TimePickerDemo setDate={setDate} date={date} />
+          {/* <TimePickerDemo setDate={setDate} date={date} /> */}
+          <TimePicker12Demo date={date} setDate={setDate} />
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/time-picker/date-time-picker-demo.tsx
+++ b/src/components/time-picker/date-time-picker-demo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { format } from "date-fns";
+import { add, format } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -17,6 +17,22 @@ import { TimePicker12Demo } from "./time-picker-12hour-demo";
 
 export function DatePickerDemo() {
   const [date, setDate] = React.useState<Date>();
+
+  /**
+   * carry over the current time when a user clicks a new day
+   * instead of resetting to 00:00
+   */
+  const handleSelect = (newDay: Date | undefined) => {
+    if (!newDay) return;
+    if (!date) {
+      setDate(newDay);
+      return;
+    }
+    const diff = newDay.getTime() - date.getTime();
+    const diffInDays = diff / (1000 * 60 * 60 * 24);
+    const newDateFull = add(date, { days: Math.ceil(diffInDays) });
+    setDate(newDateFull);
+  };
 
   return (
     <Popover>
@@ -36,7 +52,7 @@ export function DatePickerDemo() {
         <Calendar
           mode="single"
           selected={date}
-          onSelect={setDate}
+          onSelect={(d) => handleSelect(d)}
           initialFocus
         />
         <div className="p-3 border-t border-border">

--- a/src/components/time-picker/date-time-picker-demo.tsx
+++ b/src/components/time-picker/date-time-picker-demo.tsx
@@ -40,8 +40,8 @@ export function DatePickerDemo() {
           initialFocus
         />
         <div className="p-3 border-t border-border">
-          {/* <TimePickerDemo setDate={setDate} date={date} /> */}
-          <TimePicker12Demo date={date} setDate={setDate} />
+          <TimePickerDemo setDate={setDate} date={date} />
+          {/* <TimePicker12Demo date={date} setDate={setDate} /> */}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/time-picker/period-select.tsx
+++ b/src/components/time-picker/period-select.tsx
@@ -70,3 +70,5 @@ export const TimePeriodSelect = React.forwardRef<
     </div>
   );
 });
+
+TimePeriodSelect.displayName = "TimePeriodSelect";

--- a/src/components/time-picker/period-select.tsx
+++ b/src/components/time-picker/period-select.tsx
@@ -8,20 +8,65 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Period, display12HourValue, setDateByType } from "./time-picker-utils";
 
-export function TimePeriodSelect() {
-  const date = new Date();
+export interface PeriodSelectorProps {
+  period: Period;
+  setPeriod: (m: Period) => void;
+  date: Date | undefined;
+  setDate: (date: Date | undefined) => void;
+  onRightFocus?: () => void;
+  onLeftFocus?: () => void;
+}
+
+export const TimePeriodSelect = React.forwardRef<
+  HTMLButtonElement,
+  PeriodSelectorProps
+>(({ period, setPeriod, date, setDate, onLeftFocus, onRightFocus }, ref) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowRight") onRightFocus?.();
+    if (e.key === "ArrowLeft") onLeftFocus?.();
+  };
+
+  const handleValueChange = (value: Period) => {
+    setPeriod(value);
+
+    /**
+     * trigger an update whenever the user switches between AM and PM;
+     * otherwise user must manually change the hour each time
+     */
+    if (date) {
+      const tempDate = new Date(date);
+      const hours = display12HourValue(date.getHours());
+      setDate(
+        setDateByType(
+          tempDate,
+          hours.toString(),
+          "12hours",
+          period === "AM" ? "PM" : "AM"
+        )
+      );
+    }
+  };
+
   return (
     <div className="flex h-10 items-center">
-      <Select defaultValue={date && date?.getHours() > 12 ? "pm" : "am"}>
-        <SelectTrigger className="w-[65px]">
+      <Select
+        defaultValue={period}
+        onValueChange={(value: Period) => handleValueChange(value)}
+      >
+        <SelectTrigger
+          ref={ref}
+          className="w-[65px] focus:bg-accent focus:text-accent-foreground"
+          onKeyDown={handleKeyDown}
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="am">AM</SelectItem>
-          <SelectItem value="pm">PM</SelectItem>
+          <SelectItem value="AM">AM</SelectItem>
+          <SelectItem value="PM">PM</SelectItem>
         </SelectContent>
       </Select>
     </div>
   );
-}
+});

--- a/src/components/time-picker/time-picker-12hour-demo.tsx
+++ b/src/components/time-picker/time-picker-12hour-demo.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import * as React from "react";
+import { Label } from "@/components/ui/label";
+import { TimePickerInput } from "./time-picker-input";
+import { TimePeriodSelect } from "./period-select";
+import { Period } from "./time-picker-utils";
+
+interface TimePickerDemoProps {
+  date: Date | undefined;
+  setDate: (date: Date | undefined) => void;
+}
+
+export function TimePicker12Demo({ date, setDate }: TimePickerDemoProps) {
+  const [period, setPeriod] = React.useState<Period>("PM");
+
+  const minuteRef = React.useRef<HTMLInputElement>(null);
+  const hourRef = React.useRef<HTMLInputElement>(null);
+  const secondRef = React.useRef<HTMLInputElement>(null);
+  const periodRef = React.useRef<HTMLButtonElement>(null);
+
+  return (
+    <div className="flex items-end gap-2">
+      <div className="grid gap-1 text-center">
+        <Label htmlFor="hours" className="text-xs">
+          Hours
+        </Label>
+        <TimePickerInput
+          picker="12hours"
+          period={period}
+          date={date}
+          setDate={setDate}
+          ref={hourRef}
+          onRightFocus={() => minuteRef.current?.focus()}
+        />
+      </div>
+      <div className="grid gap-1 text-center">
+        <Label htmlFor="minutes" className="text-xs">
+          Minutes
+        </Label>
+        <TimePickerInput
+          picker="minutes"
+          id="minutes12"
+          date={date}
+          setDate={setDate}
+          ref={minuteRef}
+          onLeftFocus={() => hourRef.current?.focus()}
+          onRightFocus={() => secondRef.current?.focus()}
+        />
+      </div>
+      <div className="grid gap-1 text-center">
+        <Label htmlFor="seconds" className="text-xs">
+          Seconds
+        </Label>
+        <TimePickerInput
+          picker="seconds"
+          id="seconds12"
+          date={date}
+          setDate={setDate}
+          ref={secondRef}
+          onLeftFocus={() => minuteRef.current?.focus()}
+          onRightFocus={() => periodRef.current?.focus()}
+        />
+      </div>
+      <div className="grid gap-1 text-center">
+        <Label htmlFor="period" className="text-xs">
+          Period
+        </Label>
+        <TimePeriodSelect
+          period={period}
+          setPeriod={setPeriod}
+          date={date}
+          setDate={setDate}
+          ref={periodRef}
+          onLeftFocus={() => secondRef.current?.focus()}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/time-picker/time-picker-12hour-wrapper.tsx
+++ b/src/components/time-picker/time-picker-12hour-wrapper.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import * as React from "react";
+import { TimePicker12Demo } from "./time-picker-12hour-demo";
+
+export function TimePicker12HourWrapper() {
+  const [date, setDate] = React.useState<Date>();
+  return <TimePicker12Demo setDate={setDate} date={date} />;
+}

--- a/src/components/time-picker/time-picker-input.tsx
+++ b/src/components/time-picker/time-picker-input.tsx
@@ -3,10 +3,12 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import React from "react";
 import {
+  Period,
   TimePickerType,
   getArrowByType,
   getDateByType,
   setDateByType,
+  display12HourValue,
 } from "./time-picker-utils";
 
 export interface TimePickerInputProps
@@ -14,6 +16,7 @@ export interface TimePickerInputProps
   picker: TimePickerType;
   date: Date | undefined;
   setDate: (date: Date | undefined) => void;
+  period?: Period;
   onRightFocus?: () => void;
   onLeftFocus?: () => void;
 }
@@ -34,6 +37,7 @@ const TimePickerInput = React.forwardRef<
       onChange,
       onKeyDown,
       picker,
+      period,
       onLeftFocus,
       onRightFocus,
       ...props
@@ -56,10 +60,12 @@ const TimePickerInput = React.forwardRef<
       }
     }, [flag]);
 
-    const calculatedValue = React.useMemo(
-      () => getDateByType(date, picker),
-      [date, picker]
-    );
+    const calculatedValue = React.useMemo(() => {
+      if (picker === "12hours") {
+        return display12HourValue(date.getHours());
+      }
+      return getDateByType(date, picker);
+    }, [date, picker ]);
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Tab") return;
@@ -71,7 +77,8 @@ const TimePickerInput = React.forwardRef<
         const newValue = getArrowByType(calculatedValue, step, picker);
         if (flag) setFlag(false);
         const tempDate = new Date(date);
-        setDate(setDateByType(tempDate, newValue, picker));
+        setDate(setDateByType(tempDate, newValue, picker, period));
+        console.log(date);
       }
       if (e.key >= "0" && e.key <= "9") {
         const newValue = !flag
@@ -80,7 +87,7 @@ const TimePickerInput = React.forwardRef<
         if (flag) onRightFocus?.();
         setFlag((prev) => !prev);
         const tempDate = new Date(date);
-        setDate(setDateByType(tempDate, newValue, picker));
+        setDate(setDateByType(tempDate, newValue, picker, period));
       }
     };
 

--- a/src/components/time-picker/time-picker-input.tsx
+++ b/src/components/time-picker/time-picker-input.tsx
@@ -78,7 +78,6 @@ const TimePickerInput = React.forwardRef<
         if (flag) setFlag(false);
         const tempDate = new Date(date);
         setDate(setDateByType(tempDate, newValue, picker, period));
-        console.log(date);
       }
       if (e.key >= "0" && e.key <= "9") {
         const newValue = !flag

--- a/src/components/time-picker/time-picker-input.tsx
+++ b/src/components/time-picker/time-picker-input.tsx
@@ -8,7 +8,6 @@ import {
   getArrowByType,
   getDateByType,
   setDateByType,
-  display12HourValue,
 } from "./time-picker-utils";
 
 export interface TimePickerInputProps
@@ -61,11 +60,19 @@ const TimePickerInput = React.forwardRef<
     }, [flag]);
 
     const calculatedValue = React.useMemo(() => {
-      if (picker === "12hours") {
-        return display12HourValue(date.getHours());
-      }
       return getDateByType(date, picker);
-    }, [date, picker ]);
+    }, [date, picker]);
+
+    const calculateNewValue = (key: string) => {
+      /*
+       * If picker is '12hours' and the first digit is 0, then the second digit is automatically set to 1.
+       * The second entered digit will break the condition and the value will be set to 10-12.
+       */
+      if (picker === "12hours" && flag && calculatedValue.slice(0, 1) === "0") {
+        return "0" + key;
+      }
+      return !flag ? "0" + key : calculatedValue.slice(1, 2) + key;
+    };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Tab") return;
@@ -80,9 +87,7 @@ const TimePickerInput = React.forwardRef<
         setDate(setDateByType(tempDate, newValue, picker, period));
       }
       if (e.key >= "0" && e.key <= "9") {
-        const newValue = !flag
-          ? "0" + e.key
-          : calculatedValue.slice(1, 2) + e.key;
+        const newValue = calculateNewValue(e.key);
         if (flag) onRightFocus?.();
         setFlag((prev) => !prev);
         const tempDate = new Date(date);

--- a/src/components/time-picker/time-picker-utils.ts
+++ b/src/components/time-picker/time-picker-utils.ts
@@ -145,7 +145,8 @@ export function getDateByType(date: Date, type: TimePickerType) {
     case "hours":
       return getValidHour(String(date.getHours()));
     case "12hours":
-      return getValid12Hour(String(date.getHours()));
+      const hours = display12HourValue(date.getHours());
+      return getValid12Hour(String(hours));
     default:
       return "00";
   }

--- a/src/components/time-picker/time-picker-utils.ts
+++ b/src/components/time-picker/time-picker-utils.ts
@@ -48,7 +48,7 @@ export function getValidHour(value: string) {
 
 export function getValid12Hour(value: string) {
   if (isValid12Hour(value)) return value;
-  return getValidNumber(value, { max: 12 });
+  return getValidNumber(value, { min: 1, max: 12 });
 }
 
 export function getValidMinuteOrSecond(value: string) {
@@ -78,6 +78,10 @@ export function getValidArrowHour(value: string, step: number) {
   return getValidArrowNumber(value, { min: 0, max: 23, step });
 }
 
+export function getValidArrow12Hour(value: string, step: number) {
+  return getValidArrowNumber(value, { min: 1, max: 12, step });
+}
+
 export function getValidArrowMinuteOrSecond(value: string, step: number) {
   return getValidArrowNumber(value, { min: 0, max: 59, step });
 }
@@ -100,9 +104,22 @@ export function setHours(date: Date, value: string) {
   return date;
 }
 
-export type TimePickerType = "minutes" | "seconds" | "hours"; // | "12hours";
+export function set12Hours(date: Date, value: string, period: Period) {
+  const hours = parseInt(getValid12Hour(value), 10);
+  const convertedHours = convert12HourTo24Hour(hours, period);
+  date.setHours(convertedHours);
+  return date;
+}
 
-export function setDateByType(date: Date, value: string, type: TimePickerType) {
+export type TimePickerType = "minutes" | "seconds" | "hours" | "12hours";
+export type Period = "AM" | "PM";
+
+export function setDateByType(
+  date: Date,
+  value: string,
+  type: TimePickerType,
+  period?: Period
+) {
   switch (type) {
     case "minutes":
       return setMinutes(date, value);
@@ -110,6 +127,10 @@ export function setDateByType(date: Date, value: string, type: TimePickerType) {
       return setSeconds(date, value);
     case "hours":
       return setHours(date, value);
+    case "12hours": {
+      if (!period) return date;
+      return set12Hours(date, value, period);
+    }
     default:
       return date;
   }
@@ -123,6 +144,8 @@ export function getDateByType(date: Date, type: TimePickerType) {
       return getValidMinuteOrSecond(String(date.getSeconds()));
     case "hours":
       return getValidHour(String(date.getHours()));
+    case "12hours":
+      return getValid12Hour(String(date.getHours()));
     default:
       return "00";
   }
@@ -140,7 +163,40 @@ export function getArrowByType(
       return getValidArrowMinuteOrSecond(value, step);
     case "hours":
       return getValidArrowHour(value, step);
+    case "12hours":
+      return getValidArrow12Hour(value, step);
     default:
       return "00";
   }
+}
+
+/**
+ * handles value change of 12-hour input
+ * 12:00 PM is 12:00
+ * 12:00 AM is 00:00
+ */
+export function convert12HourTo24Hour(hour: number, period: Period) {
+  if (period === "PM") {
+    if (hour <= 11) {
+      return hour + 12;
+    } else {
+      return hour;
+    }
+  } else if (period === "AM") {
+    if (hour === 12) return 0;
+    return hour;
+  }
+  return hour;
+}
+
+/**
+ * time is stored in the 24-hour form,
+ * but needs to be displayed to the user
+ * in its 12-hour representation
+ */
+export function display12HourValue(hours: number) {
+  if (hours === 0 || hours === 12) return "12";
+  if (hours >= 22) return `${hours - 12}`;
+  if (hours % 12 > 9) return `${hours}`;
+  return `0${hours % 12}`;
 }


### PR DESCRIPTION
Introduces a new component that supports 12-hour clocks. As I expanded on the already-present skeleton for this feature, it will need the shadcn Select component to work. 

It will properly loop between 1 and 12, supports right-left arrow navigation, and will automatically update the time whenever the user switches between AM and PM.

The time is stored internally in the 24-hour format, but presented to the user in the 12-hour format.


https://github.com/openstatusHQ/time-picker/assets/101513222/0967cabd-3126-4280-b77a-17e5850b6e1d

