### PR TITLE
Fix double-digit values for 12hour version

### DIFF
--- a/src/components/time-picker/time-picker-input.tsx
+++ b/src/components/time-picker/time-picker-input.tsx
@@ -44,6 +44,7 @@ const TimePickerInput = React.forwardRef<
     ref
   ) => {
     const [flag, setFlag] = React.useState<boolean>(false);
+    const [prevIntKey, setPrevIntKey] = React.useState<string>("0");
 
     /**
      * allow the user to enter the second digit within 2 seconds
@@ -68,9 +69,11 @@ const TimePickerInput = React.forwardRef<
        * If picker is '12hours' and the first digit is 0, then the second digit is automatically set to 1.
        * The second entered digit will break the condition and the value will be set to 10-12.
        */
-      if (picker === "12hours" && flag && calculatedValue.slice(0, 1) === "0") {
-        return "0" + key;
+      if (picker === "12hours") {
+        if (flag && calculatedValue.slice(1, 2) === "1" && prevIntKey === "0")
+          return "0" + key;
       }
+
       return !flag ? "0" + key : calculatedValue.slice(1, 2) + key;
     };
 
@@ -87,6 +90,8 @@ const TimePickerInput = React.forwardRef<
         setDate(setDateByType(tempDate, newValue, picker, period));
       }
       if (e.key >= "0" && e.key <= "9") {
+        if (picker === "12hours") setPrevIntKey(e.key);
+
         const newValue = calculateNewValue(e.key);
         if (flag) onRightFocus?.();
         setFlag((prev) => !prev);


### PR DESCRIPTION
While using the 12hour wrapper, the`time-picker-input` component will now properly handle keyboard input of 10, 11, or 12.

https://github.com/openstatusHQ/time-picker/assets/101513222/74a549e2-3edd-4aaa-85a0-ddf3e30d573d

Closes #8 

